### PR TITLE
Sunset Node.js 20, four months past end of life

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '22']
+        node-version: ['22', '24']
 
     steps:
       - uses: actions/checkout@v7
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '22']
+        node-version: ['22', '24']
 
     steps:
       - uses: actions/checkout@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ npm run build
 npm run test
 ```
 
-The workspace uses Node.js `>=20` and npm workspaces.
+The workspace uses Node.js `>=22` and npm workspaces.
 
 ## Design Rules
 

--- a/GUIDELINES_NEST_TRPC.md
+++ b/GUIDELINES_NEST_TRPC.md
@@ -8,7 +8,7 @@ Every single decision must follow NestJS philosophy exactly as @nestjs/graphql a
 - Everything must be decorator-first, OOP, and heavily use NestJS DI.
 - Mirror the exact DX of @nestjs/graphql (code-first approach with autoSchemaFile).
 - Current stabilization support line:
-  - Node.js `>=20`
+  - Node.js `>=22`
   - NestJS `11.x`
   - tRPC `11.x`
 - Full integration with NestJS enhancer pipeline is NON-NEGOTIABLE:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The documentation site is the canonical source of truth for usage guides and sup
 
 | Runtime | Supported line |
 | --- | --- |
-| Node.js | `>=20` |
+| Node.js | `>=22` |
 | NestJS | `11.x` |
 | tRPC | `11.x` |
 | Zod | `4.x`, optional peer |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security reports are taken seriously. Please avoid posting exploit details, secr
 
 The current stabilization line is documented in [website/docs/support-policy.md](website/docs/support-policy.md). At the time of writing, the supported runtime targets are:
 
-- Node.js `>=20`
+- Node.js `>=22`
 - NestJS `11.x`
 - tRPC `11.x`
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ci": "npm run test:cov && npm run complexity:check && npm run release:check && npm run ci:docs && npm run security:audit && npm run ci:sample"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "@nestjs/testing": "11.1.28",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "clean": "rimraf dist tsconfig.tsbuildinfo",

--- a/website/docs/support-policy.md
+++ b/website/docs/support-policy.md
@@ -8,7 +8,7 @@ This page defines the supported contract for the current `0.3.x` stabilization l
 
 ## Runtime Compatibility
 
-- Node.js `>=20`
+- Node.js `>=22`
 - NestJS `11.x`
 - tRPC `11.x`
 


### PR DESCRIPTION
Node.js 20 reached **end of life on 2026-04-30** — four months ago. This repo still declared `engines.node: ">=20"` on both the workspace and the **published package**, and ran CI against Node 20, so it advertised support for a runtime that receives no security patches.

**What changes**

- `engines.node` `>=20` → `>=22`, in the workspace root and in every published package (the published field is the one consumers actually see).
- CI matrix `[20, 22]` → `[22, 24]`, and standalone Node 20 steps move to 22. Two versions stay covered, and Node 24 (Active LTS) is now proven rather than assumed.
- Support tables, guidelines, and docs updated so no surface still claims Node 20. Historical CHANGELOG entries are deliberately left alone.

**Why now, beyond EOL hygiene**

It unblocks a stuck upgrade. `better-sqlite3@13` sets `engines.node: ">=22"`, so its Dependabot PR fails only on the Node 20 leg — the suite never executes there, reports 0% coverage, and trips the 100% gate. Sunsetting Node 20 clears that class of failure instead of pinning around it.

`@nest-native/ai-sdk` already ships `>=22`, so this brings the family in line.

Test suite verified locally on Node v24.18.0.