### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.7.0
+
 - NestJS 12 support: the published `@nestjs/common` and `@nestjs/core` peer
   ranges widen from `^11.0.0` to `^11.0.0 || ^12.0.0`. The only code change is
   internal: NestJS 12 is ESM-only and its exports map resolves files, not

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "typescript": "6.0.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -14564,7 +14564,7 @@
     },
     "packages/trpc": {
       "name": "@nest-native/trpc",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^11.1.28",
@@ -14575,11 +14575,11 @@
         "typescript": "6.0.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@nestjs/common": "^11.0.0",
-        "@nestjs/core": "^11.0.0",
+        "@nestjs/common": "^11.0.0 || ^12.0.0",
+        "@nestjs/core": "^11.0.0 || ^12.0.0",
         "@trpc/server": "^11.0.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0",
         "rxjs": "^7.0.0",
@@ -14596,7 +14596,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15593,7 +15593,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15614,7 +15614,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15635,7 +15635,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15656,7 +15656,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15678,7 +15678,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15701,7 +15701,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15723,7 +15723,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15841,7 +15841,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15862,7 +15862,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "11.1.28",
@@ -15884,7 +15884,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15905,7 +15905,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/microservices": "11.1.28",
@@ -15928,10 +15928,10 @@
       "license": "MIT",
       "dependencies": {
         "@angular/common": "22.1.0",
-        "@angular/compiler": "^22.1.3",
+        "@angular/compiler": "22.1.3",
         "@angular/core": "22.1.0",
         "@angular/platform-browser": "22.1.0",
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",
@@ -15946,7 +15946,7 @@
       "devDependencies": {
         "@angular/build": "22.1.5",
         "@angular/cli": "22.1.5",
-        "@angular/compiler-cli": "^22.1.3",
+        "@angular/compiler-cli": "22.1.3",
         "@nestjs/cli": "11.0.24",
         "@types/node": "26.2.0",
         "rimraf": "6.1.3",
@@ -17739,7 +17739,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.6.0",
+        "@nest-native/trpc": "0.7.0",
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
         "@nestjs/platform-express": "11.1.28",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-native/trpc",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Decorator-first tRPC integration bridge for NestJS",
   "keywords": [
     "nestjs",

--- a/sample/00-showcase/package.json
+++ b/sample/00-showcase/package.json
@@ -31,7 +31,7 @@
     "class-validator": "0.15.1",
     "eventsource": "4.1.0",
     "fastify": "5.12.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",

--- a/sample/01-basics-query-mutation/package.json
+++ b/sample/01-basics-query-mutation/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/02-enhancers-guards-pipes-filters/package.json
+++ b/sample/02-enhancers-guards-pipes-filters/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/03-context-request-scope/package.json
+++ b/sample/03-context-request-scope/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/04-validation-zod/package.json
+++ b/sample/04-validation-zod/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",

--- a/sample/05-validation-class-validator/package.json
+++ b/sample/05-validation-class-validator/package.json
@@ -20,7 +20,7 @@
     "@trpc/server": "^11.16.0",
     "class-transformer": "0.5.1",
     "class-validator": "0.15.1",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/06-subscriptions/package.json
+++ b/sample/06-subscriptions/package.json
@@ -21,7 +21,7 @@
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
     "eventsource": "4.1.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/07-express-fastify/package.json
+++ b/sample/07-express-fastify/package.json
@@ -22,7 +22,7 @@
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
     "fastify": "5.12.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/08-autoschema-client-typecheck/package.json
+++ b/sample/08-autoschema-client-typecheck/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/09-forrootasync-config-middleware/package.json
+++ b/sample/09-forrootasync-config-middleware/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/10-nested-alias-routers/package.json
+++ b/sample/10-nested-alias-routers/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/11-microservice-transport/package.json
+++ b/sample/11-microservice-transport/package.json
@@ -20,7 +20,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/12-angular-fullstack-showcase/package.json
+++ b/sample/12-angular-fullstack-showcase/package.json
@@ -32,7 +32,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",

--- a/sample/13-transformer-error-formatting/package.json
+++ b/sample/13-transformer-error-formatting/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.6.0",
+    "@nest-native/trpc": "0.7.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",


### PR DESCRIPTION
Publishes the NestJS 12 support merged in #159. A widened peer range only reaches consumers once it is on npm.

**Minor, not patch** — the supported peer range grows to `^11.0.0 || ^12.0.0`, which is new capability.

This is one of the two repos where NestJS 12 needed a real code change: `context/trpc-context-creator.ts` imported `Controller` from `@nestjs/common/interfaces`, a **directory**, which NestJS 12's ESM exports map (`"./*": "./*.js"`) no longer resolves. It is now a local alias — in 12 the type is literally `export type Controller = object`.

#159 also added `check-compat-tables`, which pins the Node.js and NestJS rows of five documentation pages to `packages/trpc/package.json`, so the manifest and the docs cannot drift apart. It reports on this release:

```
Compatibility tables OK: 5 pages state Node.js >=22 and NestJS ^11.0.0 || ^12.0.0.
```

Version, all 14 sample pins, the lockfile and the CHANGELOG section move together.

Gates: `npm run ci` exit 0 — 216 passing, 100% coverage on all four axes, README links, version sync, compatibility tables, pack validation 54 files, production supply-chain audit clean.