### PR TITLE
Build the package before typechecking the workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "postinstall": "npm run build --workspace @nest-native/trpc",
     "build": "npm run build --workspaces --if-present",
-    "typecheck": "npm run typecheck --workspaces --if-present",
+    "typecheck": "npm run build --workspace @nest-native/trpc && npm run typecheck --workspaces --if-present",
     "test": "TS_NODE_PROJECT=tsconfig.spec.json node --loader ts-node/esm ./node_modules/mocha/bin/mocha \"packages/**/*.spec.ts\"",
     "test:cov": "TS_NODE_PROJECT=tsconfig.spec.json nyc node --loader ts-node/esm ./node_modules/mocha/bin/mocha \"packages/**/*.spec.ts\"",
     "test:watch": "TS_NODE_PROJECT=tsconfig.spec.json node --loader ts-node/esm ./node_modules/mocha/bin/mocha -w --watch-files \"packages\" \"packages/**/*.spec.ts\"",


### PR DESCRIPTION
Fixes #160.

`npm run ci` — the command CONTRIBUTING tells a new contributor to run — died at its first step on a fresh clone. `typecheck` ran `--workspaces` over the samples, which import `@nest-native/trpc` by name; that symlink resolves to `packages/trpc`, whose `types`/`exports` point into an unbuilt `dist/`.

## It surfaces differently here

The sibling repos fail with `TS2307` diagnostics. This one fails earlier and louder, because `sample/13-transformer-error-formatting` runs `generate:types` through `ts-node` before `tsc`:

```
Error: Cannot find module '@nest-native/trpc'
  code: 'MODULE_NOT_FOUND',
  path: '.../trpc/node_modules/@nest-native/trpc'
npm error Lifecycle script `generate:types` failed
```

Same cause, same fix — worth noting so the symptom is recognisable.

## Verified both directions, from the same unbuilt tree

```
$ rm -rf packages/trpc/dist
$ npm run typecheck --workspaces --if-present    # old: EXIT=1, MODULE_NOT_FOUND
$ npm run typecheck                               # new: EXIT=0, clean
```

## The fix

```
"typecheck": "npm run build --workspace @nest-native/trpc && npm run typecheck --workspaces --if-present"
```

The shape `nest-native/lockout` and `nest-native/cache` already use, which is why neither was affected.