### PR TITLE
Point contributors at the guidelines file that exists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for helping improve `@nest-native/trpc`. This project is a community package, but its design bar is intentionally strict: it should feel native in NestJS projects, not like tRPC internals exposed through a thin wrapper.
 
-If you use an AI coding agent, point it at [AI_CODING_GUIDELINES.md](AI_CODING_GUIDELINES.md). That file is written primarily for agentic coding workflows and captures the project-specific architecture, public API tiers, security review, and release/version rules that an agent should preserve while editing the repo.
+If you use an AI coding agent, point it at [GUIDELINES_NEST_TRPC.md](GUIDELINES_NEST_TRPC.md). That file is binding — `CLAUDE.md` imports it — and captures the project-specific architecture (§1), public API tiers (§2), security review (§8), and release/version rules (§9) that an agent should preserve while editing the repo.
 
 ## Local Setup
 


### PR DESCRIPTION
Fixes #161.

`CONTRIBUTING.md:5` sent contributors — and explicitly AI coding agents — to a file that is not in the tree:

```
If you use an AI coding agent, point it at [AI_CODING_GUIDELINES.md](AI_CODING_GUIDELINES.md).
```

It was removed in `cba976f` and the link was never updated.

## Where the content actually lives

Verified section by section rather than assumed — `GUIDELINES_NEST_TRPC.md` covers everything the dead link promised:

| Promised | Section |
| --- | --- |
| project-specific architecture | §1 Overall Architecture Assumptions |
| public API tiers | §2 Public API Assumptions |
| security review | §8 Security Review Requirements (MANDATORY) |
| release/version rules | §9 Release Version Synchronization (MANDATORY) |

`CLAUDE.md` already `@`-imports that file and calls it binding, so this makes the two agent-facing entry points agree instead of contradicting each other.

Also checked every other relative link in `CONTRIBUTING.md`: `RELEASING.md` resolves, and no others are broken.